### PR TITLE
新增 `LoadEmptyBitmap` 來創立空白的 `CMovingBitmap` 物件

### DIFF
--- a/Source/Library/gamecore.h
+++ b/Source/Library/gamecore.h
@@ -84,9 +84,11 @@ namespace game_framework {
 		static bool  CreateSurfaceWindowed();
 		static void  LoadBitmap(int i, int IDB_BITMAP);
 		static void  LoadBitmap(int i, char *filename);
+		static void  LoadBitmapFromExistHBITMAP(int i, HBITMAP bitmap);
 		static DWORD MatchColorKey(LPDIRECTDRAWSURFACE lpDDSurface, COLORREF color);
 		static int   RegisterBitmap(int IDB_BITMAP, COLORREF ColorKey);
 		static int   RegisterBitmap(char *filename, COLORREF ColorKey);
+		static int   RegisterBitmapWithHBITMAP(HBITMAP hbitmap);
 		static void  ReleaseSurface();
 		static void  RestoreSurface();
 		static void  SetColorKey(unsigned SurfaceID, COLORREF color);

--- a/Source/Library/gameutil.cpp
+++ b/Source/Library/gameutil.cpp
@@ -100,6 +100,34 @@ namespace game_framework {
 		}
 	}
 
+	void CMovingBitmap::LoadEmptyBitmap(int height, int width) {
+		const int nx = 0;
+		const int ny = 0;
+
+		HBITMAP hbitmap = CreateBitmap(width, height, 1, 32, NULL);
+
+		/* Fill white color to bitmap */
+		HDC hdc = CreateCompatibleDC(NULL);
+		HBITMAP hOldBitmap = (HBITMAP)SelectObject(hdc, hbitmap);
+		PatBlt(hdc, 0, 0, width, height, WHITENESS);
+		SelectObject(hdc, hOldBitmap);
+		DeleteDC(hdc);
+
+		CBitmap *bmp = CBitmap::FromHandle(hbitmap); // memory will be deleted automatically
+		BITMAP bitmapSize;
+		bmp->GetBitmap(&bitmapSize);
+
+		location.left = nx; 
+		location.top = ny;
+		location.right = nx + width;
+		location.bottom = ny + height;
+
+		SurfaceID.push_back(CDDraw::RegisterBitmapWithHBITMAP(hbitmap));
+		isBitmapLoaded = true;
+
+		bmp->DeleteObject();
+	}
+
 	void CMovingBitmap::UnshowBitmap()
 	{
 		GAME_ASSERT(isBitmapLoaded, "A bitmap must be loaded before SetTopLeft() is called !!!");

--- a/Source/Library/gameutil.h
+++ b/Source/Library/gameutil.h
@@ -99,6 +99,7 @@ namespace game_framework {
 		int   Width();						// 取得圖形的寬度
 		bool  IsAnimationDone();
 		int   GetMovingBitmapFrame();
+		void  LoadEmptyBitmap(int height, int weight);
 	protected:
 		int selector = 0;
 		int delayCount = 10;


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們新增了 `LoadEmptyBitmap` 函數來讓使用者讀入指定長度與寬度的白色 `CMovingBitmap`。