### PR TITLE
修復 `GetHeight()` 與 `GetWidth()` 在幀切換時數值不會變更的問題

### DIFF
--- a/Source/Library/gameutil.cpp
+++ b/Source/Library/gameutil.cpp
@@ -42,7 +42,7 @@ namespace game_framework {
 	int CMovingBitmap::GetHeight()
 	{
 		GAME_ASSERT(isBitmapLoaded, "A bitmap must be loaded before Height() is called !!!");
-		return location.bottom - location.top;
+		return locations[frameIndex].bottom - locations[frameIndex].top;
 	}
 
 	//! 取得 CMovingBitmap 物件的左上角的 x 軸座標值。
@@ -53,7 +53,7 @@ namespace game_framework {
 	int CMovingBitmap::GetLeft()
 	{
 		GAME_ASSERT(isBitmapLoaded, "A bitmap must be loaded before Left() is called !!!");
-		return location.left;
+		return locations[frameIndex].left;
 	}
 
 	//! 讀取圖片資源。
@@ -185,12 +185,15 @@ namespace game_framework {
 	void CMovingBitmap::SetTopLeft(int x, int y)
 	{
 		GAME_ASSERT(isBitmapLoaded, "A bitmap must be loaded before SetTopLeft() is called !!!");
-		int dx = location.left - x;
-		int dy = location.top - y;
-		location.left = x;
-		location.top = y;
-		location.right -= dx;
-		location.bottom -= dy;
+
+		for (int i = 0; i < int(locations.size()); i++) {
+			int dx = locations[i].left - x;
+			int dy = locations[i].top - y;
+			locations[i].left = x;
+			locations[i].top = y;
+			locations[i].right -= dx;
+			locations[i].bottom -= dy;
+		}
 	}
 
 	//! 設置圖片是否為動畫。
@@ -213,7 +216,7 @@ namespace game_framework {
 	void CMovingBitmap::ShowBitmap()
 	{
 		GAME_ASSERT(isBitmapLoaded, "A bitmap must be loaded before ShowBitmap() is called !!!");
-		CDDraw::BltBitmapToBack(surfaceID[frameIndex], location.left, location.top);
+		CDDraw::BltBitmapToBack(surfaceID[frameIndex], locations[frameIndex].left, locations[frameIndex].top);
 		ShowBitmapBySetting();
 	}
 
@@ -225,7 +228,7 @@ namespace game_framework {
 	void CMovingBitmap::ShowBitmap(double factor)
 	{
 		GAME_ASSERT(isBitmapLoaded, "A bitmap must be loaded before ShowBitmap() is called !!!");
-		CDDraw::BltBitmapToBack(surfaceID[frameIndex], location.left, location.top, factor);
+		CDDraw::BltBitmapToBack(surfaceID[frameIndex], locations[frameIndex].left, locations[frameIndex].top, factor);
 		ShowBitmapBySetting();
 	}
 
@@ -254,7 +257,7 @@ namespace game_framework {
 	int CMovingBitmap::GetTop()
 	{
 		GAME_ASSERT(isBitmapLoaded, "A bitmap must be loaded before Top() is called !!!");
-		return location.top;
+		return locations[frameIndex].top;
 	}
 
 	//! 取得當前圖片寬度。
@@ -264,7 +267,7 @@ namespace game_framework {
 	int CMovingBitmap::GetWidth()
 	{
 		GAME_ASSERT(isBitmapLoaded, "A bitmap must be loaded before Width() is called !!!");
-		return location.right - location.left;
+		return locations[frameIndex].right - locations[frameIndex].left;
 	}
 	
 	//! 啟動單次動畫。
@@ -324,11 +327,12 @@ namespace game_framework {
 	void CMovingBitmap::InitializeRectByBITMAP(BITMAP bitmapSize) {
 		const unsigned NX = 0;
 		const unsigned NY = 0;
-
-		location.left = NX;
-		location.top = NY;
-		location.right = NX + bitmapSize.bmWidth;
-		location.bottom = NY + bitmapSize.bmHeight;
+		CRect newCrect;
+		newCrect.left = NX;
+		newCrect.top = NY;
+		newCrect.right = NX + bitmapSize.bmWidth;
+		newCrect.bottom = NY + bitmapSize.bmHeight;
+		locations.push_back(newCrect);
 	}
 
 	//! 根據使用者設定的參數來顯示圖片。
@@ -373,7 +377,7 @@ namespace game_framework {
 	*/
 	bool CMovingBitmap::IsOverlap(CMovingBitmap bmp1, CMovingBitmap bmp2) {
 		CRect rect;
-		BOOL isOverlap = rect.IntersectRect(bmp1.location, bmp2.location);
+		BOOL isOverlap = rect.IntersectRect(bmp1.locations[bmp1.GetFrameIndexOfBitmap()], bmp2.locations[bmp1.GetFrameIndexOfBitmap()]);
 		return isOverlap;
 	}
 

--- a/Source/Library/gameutil.cpp
+++ b/Source/Library/gameutil.cpp
@@ -377,7 +377,7 @@ namespace game_framework {
 	*/
 	bool CMovingBitmap::IsOverlap(CMovingBitmap bmp1, CMovingBitmap bmp2) {
 		CRect rect;
-		BOOL isOverlap = rect.IntersectRect(bmp1.locations[bmp1.GetFrameIndexOfBitmap()], bmp2.locations[bmp1.GetFrameIndexOfBitmap()]);
+		BOOL isOverlap = rect.IntersectRect(bmp1.locations[bmp1.GetFrameIndexOfBitmap()], bmp2.locations[bmp2.GetFrameIndexOfBitmap()]);
 		return isOverlap;
 	}
 

--- a/Source/Library/gameutil.h
+++ b/Source/Library/gameutil.h
@@ -137,7 +137,7 @@ namespace game_framework {
 		bool isBitmapLoaded = false;	// whether a bitmap has been loaded
 		//! 儲存物件動畫是否為單次動畫
 		bool isOnce = false;
-		CRect    location;			// location of the bitmap
+		vector<CRect>    locations;			// location of the bitmap
 		vector<unsigned> surfaceID;
 		clock_t last_time = clock();
 		//! 儲存物件讀取的圖片路徑


### PR DESCRIPTION
## What's happen?

在這份 PR 中，我們修復了 `GetHeight()` 與 `GetWidth()` 在幀切換時數值不會變更的問題。
我們順便考量了不同的 frame 會不會出現在不同的 top-left 座標的問題，現在強制它們會一致。

感謝 @Dragonfly911117 提供了有關這個 bug 的資訊。

Resolved: #19